### PR TITLE
Add thesis removal command

### DIFF
--- a/tests/fixtures/thesis.n3
+++ b/tests/fixtures/thesis.n3
@@ -16,6 +16,6 @@
                        bibo:handle <http://handle.org/1> ;
                        mods:note "This is a thesis" ;
                        pcdm:hasFile <mock://example.com/bar> ,
-                                    <mock:example.com/baz> .
+                                    <mock://example.com/baz> .
 <mock://example.com/bar> a pcdm:File .
 <mock://example.com/baz> a pcdm:File .

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,10 +1,23 @@
+from operator import attrgetter
+from unittest.mock import MagicMock
+
+from elasticsearch_dsl.connections import connections
 import pytest
-from rdflib import Graph, URIRef, Literal
+from rdflib import Graph, URIRef
 import requests_mock
 
-from pit.index import (create_thesis, DocumentIndexer, documents, indexable,
-                       PcdmObject, ThesisResource, uri_from_message)
-from pit.namespaces import *
+from pit.index import (
+    create_thesis,
+    delete_from_index,
+    delete_from_repo,
+    documents,
+    Index,
+    indexable,
+    PcdmObject,
+    Thesis,
+    ThesisResource,
+    uri_from_message,
+)
 
 
 @pytest.fixture(scope="session")
@@ -20,9 +33,17 @@ def graph(n3):
     return g
 
 
+@pytest.yield_fixture
+def es():
+    client = MagicMock()
+    connections.add_connection('default', client)
+    yield client
+    connections.remove_connection('default')
+
+
 def test_uri_from_message_returns_uri():
     msg = ('{"@id": "mock://example.com/1", "@type": ['
-          '"http://pcdm.org/models#Object"]}')
+           '"http://pcdm.org/models#Object"]}')
     assert uri_from_message(msg) == 'mock://example.com/1'
 
 
@@ -42,7 +63,7 @@ def test_documents_generates_list_pcdm_members():
     with requests_mock.Mocker() as m:
         m.get('mock://example.com/', text=coll)
         assert sorted(documents('mock://example.com/')) == \
-                ['mock://example.com/1', 'mock://example.com/2']
+            ['mock://example.com/1', 'mock://example.com/2']
 
 
 def test_pcdm_object_has_uri(graph):
@@ -69,6 +90,29 @@ def test_indexable_returns_false_for_nonindexable_events():
         'org.fcrepo.jms.resourceType': 'http://pcdm.org/models#File'})
 
 
+def test_delete_from_index_deletes_document(es):
+    es.search.return_value = {'hits': {'hits': [{'_id': 'foobar'}]}}
+    delete_from_index('123.4', 'theses')
+    es.search.assert_called_with('theses', 'thesis',
+                                 {'query': {'term': {'handle': '123.4'}}})
+    es.delete.assert_called_with('theses', 'thesis', 'foobar')
+
+
+def test_delete_from_repo_deletes_thesis_and_files(n3):
+    with requests_mock.Mocker() as m:
+        m.get('mock://example.com/1/fcr:metadata', text=n3)
+        m.delete('mock://example.com/bar')
+        m.delete('mock://example.com/baz')
+        m.delete('mock://example.com/1')
+        delete_from_repo('mock://example.com/1')
+        r_getter = attrgetter('method', 'url')
+        reqs = [r_getter(r) for r in m.request_history]
+        assert all([r in reqs for r in [
+                    ('DELETE', 'mock://example.com/bar'),
+                    ('DELETE', 'mock://example.com/baz'),
+                    ('DELETE', 'mock://example.com/1')]])
+
+
 def test_thesis_properties_return_mutliple(graph):
     t = ThesisResource(graph)
     assert all([m in t.title for m in ['Title 1', 'Title 2']])
@@ -87,3 +131,53 @@ def test_thesis_resource_returns_properties(graph):
     assert '2002' in t.published_date
     assert 'Title 1' in t.title
     assert t.uri == 'mock://example.com/1'
+
+
+def test_index_initialize_ensures_index_alias_exists(es):
+    es.indices.exists_alias.return_value = False
+    idx = Index('theses', Thesis)
+    idx.initialize()
+    assert es.indices.create.called
+    assert es.indices.update_aliases.called
+
+
+def test_index_versions_lists_current_index_versions(es):
+    es.indices.get_alias.return_value = {'v1': 'foo', 'v2': 'bar'}
+    idx = Index('theses', Thesis)
+    assert 'v1' in idx.versions
+    assert 'v2' in idx.versions
+
+
+def test_index_versions_returns_empty_list_if_no_alias(es):
+    es.indices.return_value = False
+    assert Index('theses', Thesis).versions == []
+
+
+def test_index_new_version_creates_new_index_version(es):
+    vrs = Index('theses', Thesis).new_version()
+    assert es.indices.create.called
+    assert vrs.startswith('theses-')
+
+
+def test_current_returns_current_version(es):
+    es.indices.get_alias.return_value = {'v1': 'foo'}
+    idx = Index('theses', Thesis)
+    assert idx.current == 'v1'
+
+
+def test_index_current_sets_new_version(es):
+    es.indices.exists_alias.return_value = False
+    idx = Index('theses', Thesis)
+    idx.current = 'v3'
+    es.indices.update_aliases.assert_called_with({'actions': [
+        {'add': {'index': 'v3', 'alias': 'theses'}}]})
+
+
+def test_index_current_removes_old_versions(es):
+    es.indices.get_alias.return_value = {'v1': 'foo'}
+    idx = Index('theses', Thesis)
+    idx.current = 'v2'
+    es.indices.update_aliases.assert_called_with({'actions': [
+        {'remove': {'index': 'v1', 'alias': 'theses'}},
+        {'add': {'index': 'v2', 'alias': 'theses'}}]})
+    es.indices.delete.assert_called_with(index='v1')


### PR DESCRIPTION
This adds a new command called `remove` that can be used to remove a
specific thesis from the index and the repository.