### PR TITLE
Monkeypatch aioes for elasticsearch 5

### DIFF
--- a/pit/__init__.py
+++ b/pit/__init__.py
@@ -1,1 +1,16 @@
+import aioes
+
+
 __version__='0.3.0'
+
+
+# Monkeypatch for aioes.
+# This is a temporary fix for https://github.com/aio-libs/aioes/issues/112.
+
+_old_connection_init = aioes.connection.Connection.__init__
+
+def __new__init__(self, *args, **kwargs):
+    _old_connection_init(self, *args, **kwargs)
+    self._base_url = self._base_url.rstrip('/')
+
+aioes.connection.Connection.__init__ = __new__init__


### PR DESCRIPTION
This provides a temporary fix for aioes, which does not currently work
with ES 5.