### PR TITLE
Add host rewrite for Fedora URLs

### DIFF
--- a/pit/__init__.py
+++ b/pit/__init__.py
@@ -1,3 +1,6 @@
+import os
+from urllib.parse import urlsplit, urlunsplit
+
 import aioes
 
 
@@ -14,3 +17,15 @@ def __new__init__(self, *args, **kwargs):
     self._base_url = self._base_url.rstrip('/')
 
 aioes.connection.Connection.__init__ = __new__init__
+
+
+def rewrite_host(url):
+    host = os.environ['NGINX_PROXY_SERVICE_HOST']
+    port = os.environ['NGINX_PROXY_SERVICE_PORT']
+    parts = list(urlsplit(url))
+    if port:
+        new_host = '{}:{}'.format(host, port)
+    else:
+        new_host = host
+    parts[1] = new_host
+    return urlunsplit(parts)

--- a/pit/index.py
+++ b/pit/index.py
@@ -3,6 +3,7 @@ import logging
 import aiohttp
 import rdflib
 
+from pit import rewrite_host
 from pit.namespaces import BIBO, F4EV, MODS, MSL, PCDM, DCTERMS, RDF, RDA
 from pit.pcdm import PREFER_HEADER, PcdmObject
 
@@ -21,6 +22,7 @@ def uri_from_message(data, msg_format='json-ld'):
 
 async def create_thesis(url, client=None):
     client = aiohttp.ClientSession()
+    url = rewrite_host(url)
     resp = await client.get(url, headers={'Prefer': PREFER_HEADER,
                                           'Accept': 'text/n3'})
     data = await resp.text()

--- a/pit/pcdm.py
+++ b/pit/pcdm.py
@@ -1,5 +1,6 @@
 import rdflib
 
+from pit import rewrite_host
 from pit.namespaces import EBU, PCDM, RDF
 
 
@@ -30,8 +31,9 @@ class PcdmCollection(PcdmBase):
             m = next(self._members)
         except StopIteration:
             raise StopAsyncIteration
-        res = await self.client.get(str(m), headers={'Prefer': PREFER_HEADER,
-                                                     'Accept': 'text/n3'})
+        url = rewrite_host(str(m))
+        res = await self.client.get(url, headers={'Prefer': PREFER_HEADER,
+                                                  'Accept': 'text/n3'})
         data = await res.text()
         graph = rdflib.Graph().parse(data=data, format='n3')
         return PcdmObject(graph, self.client)
@@ -66,4 +68,5 @@ class PcdmFile(PcdmBase):
         return str(m)
 
     async def read(self):
-        return await self.client.request(str(self.uri))
+        url = rewrite_host(str(self.uri))
+        return await self.client.request(url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,12 @@ def temp_dir():
         shutil.rmtree(tmp_dir)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def kube_env():
+    os.environ['NGINX_PROXY_SERVICE_HOST'] = 'example.com'
+    os.environ['NGINX_PROXY_SERVICE_PORT'] = ''
+
+
 @pytest.fixture
 def clean_temp(temp_dir):
     for f in os.listdir(temp_dir):


### PR DESCRIPTION
The nginx proxy generates a mismatch between resource URIs in the RDF
metadata. The proper fix is to register a hostname for Fedora. This
provides a temporary fix and should be removed once that's done.